### PR TITLE
Adding author migration schema context and tests

### DIFF
--- a/lib/elixir_bookshelf/author.ex
+++ b/lib/elixir_bookshelf/author.ex
@@ -1,0 +1,27 @@
+defmodule ElixirBookshelf.Author do
+  @moduledoc """
+  The author schema represents an author record.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{
+          first_name: String.t(),
+          last_name: String.t()
+        }
+
+  @primary_key {:id, UXID, autogenerate: true, prefix: "au", size: :medium}
+  schema "authors" do
+    field :first_name, :string
+    field :last_name, :string
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(author, attrs) do
+    author
+    |> cast(attrs, [:first_name, :last_name])
+    |> validate_required([:first_name, :last_name])
+  end
+end

--- a/lib/elixir_bookshelf/authors.ex
+++ b/lib/elixir_bookshelf/authors.ex
@@ -1,0 +1,43 @@
+defmodule ElixirBookshelf.Authors do
+  @moduledoc """
+  The Authors context for CRUD operations on author records.
+  """
+  import Ecto.Query, warn: false
+
+  alias ElixirBookshelf.Author
+  alias ElixirBookshelf.Repo
+
+  @spec list_authors() :: list(Author.t())
+  def list_authors() do
+    Repo.all(Author)
+  end
+
+  @spec get_author(String.t()) :: Author.t()
+  def get_author(author_id) do
+    Repo.get(Author, author_id)
+  end
+
+  @spec get_author!(String.t()) :: Author.t()
+  def get_author!(author_id) do
+    Repo.get!(Author, author_id)
+  end
+
+  @spec create_author(map()) :: {:ok, Author.t()} | {:error, Ecto.Changeset.t()}
+  def create_author(attrs \\ %{}) do
+    %Author{}
+    |> Author.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @spec update_author(Author.t(), map()) :: {:ok, Author.t()} | {:error, Ecto.Changeset.t()}
+  def update_author(%Author{} = author, attrs) do
+    author
+    |> Author.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @spec delete_author(Author.t()) :: {:ok, Author.t()} | {:error, Ecto.Changeset.t()}
+  def delete_author(%Author{} = author) do
+    Repo.delete(author)
+  end
+end

--- a/priv/repo/migrations/20250911211047_create_authors.exs
+++ b/priv/repo/migrations/20250911211047_create_authors.exs
@@ -1,0 +1,18 @@
+defmodule ElixirBookshelf.Repo.Migrations.CreateAuthors do
+  use Ecto.Migration
+  # excellent_migrations:safety-assured-for-this-file table_dropped
+
+  def up do
+    create_if_not_exists table(:authors, primary_key: false) do
+      add :id, :string, primary_key: true
+      add :first_name, :string, null: false
+      add :last_name, :string, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+  end
+
+  def down do
+    drop_if_exists table(:authors)
+  end
+end

--- a/test/elixir_bookshelf/author_test.exs
+++ b/test/elixir_bookshelf/author_test.exs
@@ -1,0 +1,40 @@
+defmodule ElixirBookshelf.AuthorTest do
+  use ElixirBookshelf.DataCase
+
+  alias ElixirBookshelf.Author
+
+  describe "changeset/2" do
+    test "valid changeset with valid attributes" do
+      attrs = %{first_name: "Jane", last_name: "Doe"}
+      changeset = Author.changeset(%Author{}, attrs)
+
+      assert changeset.valid?
+      assert get_change(changeset, :first_name) == "Jane"
+      assert get_change(changeset, :last_name) == "Doe"
+    end
+
+    test "invalid changeset with missing first_name" do
+      attrs = %{last_name: "Doe"}
+      changeset = Author.changeset(%Author{}, attrs)
+
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).first_name
+    end
+
+    test "invalid changeset with missing last_name" do
+      attrs = %{first_name: "Jane"}
+      changeset = Author.changeset(%Author{}, attrs)
+
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).last_name
+    end
+
+    test "invalid changeset with empty attributes" do
+      changeset = Author.changeset(%Author{}, %{})
+
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).first_name
+      assert "can't be blank" in errors_on(changeset).last_name
+    end
+  end
+end

--- a/test/elixir_bookshelf/authors_test.exs
+++ b/test/elixir_bookshelf/authors_test.exs
@@ -1,0 +1,120 @@
+defmodule ElixirBookshelf.AuthorsTest do
+  use ElixirBookshelf.DataCase
+
+  alias ElixirBookshelf.Authors
+  import ElixirBookshelf.Factory
+
+  describe "list_authors/0" do
+    test "returns all authors" do
+      author_1 = insert(:author)
+      author_2 = insert(:author)
+
+      authors = Authors.list_authors()
+
+      assert length(authors) == 2
+      assert Enum.any?(authors, fn c -> c.id == author_1.id end)
+      assert Enum.any?(authors, fn c -> c.id == author_2.id end)
+    end
+
+    test "returns empty list when no authors exist" do
+      authors = Authors.list_authors()
+      assert authors == []
+    end
+  end
+
+  describe "get_author/1" do
+    test "returns the author when it exists" do
+      author = insert(:author)
+
+      result = Authors.get_author(author.id)
+
+      assert result.id == author.id
+      assert result.first_name == author.first_name
+      assert result.last_name == author.last_name
+    end
+
+    test "returns nil when author does not exist" do
+      result = Authors.get_author("nonexistent-id")
+      assert result == nil
+    end
+  end
+
+  describe "get_author!/1" do
+    test "returns the author when it exists" do
+      author = insert(:author)
+
+      result = Authors.get_author!(author.id)
+
+      assert result.id == author.id
+      assert result.first_name == author.first_name
+      assert result.last_name == author.last_name
+    end
+
+    test "raises when author does not exist" do
+      assert_raise Ecto.NoResultsError, fn ->
+        Authors.get_author!("nonexistent-id")
+      end
+    end
+  end
+
+  describe "create_author/1" do
+    test "creates an author with valid attributes" do
+      attrs = %{first_name: "Test", last_name: "Author"}
+
+      {:ok, author} = Authors.create_author(attrs)
+
+      assert author.first_name == "Test"
+      assert author.last_name == "Author"
+    end
+
+    test "returns error changeset with invalid attributes" do
+      attrs = %{first_name: "", last_name: ""}
+
+      {:error, changeset} = Authors.create_author(attrs)
+
+      assert changeset.valid? == false
+      assert "can't be blank" in errors_on(changeset).first_name
+      assert "can't be blank" in errors_on(changeset).last_name
+    end
+
+    test "empty attrs returns a error changeset tuple" do
+      {:error, changeset} = Authors.create_author()
+
+      assert changeset.valid? == false
+    end
+  end
+
+  describe "update_author/2" do
+    test "updates author with valid attributes" do
+      author = insert(:author, first_name: "Original", last_name: "Name")
+      attrs = %{first_name: "Updated", last_name: "Author"}
+
+      {:ok, updated_author} = Authors.update_author(author, attrs)
+
+      assert updated_author.first_name == "Updated"
+      assert updated_author.last_name == "Author"
+    end
+
+    test "returns error changeset with invalid attributes" do
+      author = insert(:author)
+      attrs = %{first_name: "", last_name: ""}
+
+      {:error, changeset} = Authors.update_author(author, attrs)
+
+      assert changeset.valid? == false
+      assert "can't be blank" in errors_on(changeset).first_name
+      assert "can't be blank" in errors_on(changeset).last_name
+    end
+  end
+
+  describe "delete_author/1" do
+    test "deletes the author" do
+      author = insert(:author)
+
+      {:ok, deleted_author} = Authors.delete_author(author)
+
+      assert deleted_author.id == author.id
+      assert Authors.get_author(author.id) == nil
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -3,7 +3,7 @@ defmodule ElixirBookshelf.Factory do
   An ex machina based factory for data in tests
   """
   use ExMachina.Ecto, repo: ElixirBookshelf.Repo
-  alias ElixirBookshelf.Book
+  alias ElixirBookshelf.{Author, Book}
 
   def book_factory do
     %Book{
@@ -17,6 +17,29 @@ defmodule ElixirBookshelf.Factory do
           "Authority"
         ]),
       word_count: Enum.random(0..20_000)
+    }
+  end
+
+  def author_factory do
+    %Author{
+      first_name:
+        Enum.random([
+          "Isaac",
+          "Ursula",
+          "China",
+          "Neal",
+          "Kim",
+          "Jeff"
+        ]),
+      last_name:
+        Enum.random([
+          "Asimov",
+          "Le Guin",
+          "Miéville",
+          "Stephenson",
+          "Robinson",
+          "VanderMeer"
+        ])
     }
   end
 end


### PR DESCRIPTION
Adds the author schema and supporting context and tests.

To create an author drop into IEX, alias the author, create a new one.

`iex -S mix`

```elixir
alias ElixirBookshelf.Author
author = %Author{first_name: "Stephen", last_name: "King"}
```

Should see something like this:

```elixir
%ElixirBookshelf.Author{
  __meta__: #Ecto.Schema.Metadata<:built, "authors">,
  id: nil,
  first_name: "Stephen",
  last_name: "King",
  inserted_at: nil,
  updated_at: nil
}

# alias the context

alias ElixirBookshelf.Authors

insert a similar record:

Authors.create_author(%{first_name: "Stephen", last_name: "King"})

#should see something like below
{:ok,
 %ElixirBookshelf.Author{
   __meta__: #Ecto.Schema.Metadata<:loaded, "authors">,
   id: "au_01k4z9jz02603bhwcq",
   first_name: "Stephen",
   last_name: "King",
   inserted_at: ~U[2025-09-12 15:44:30Z],
   updated_at: ~U[2025-09-12 15:44:30Z]
 }}
```



